### PR TITLE
Improve didUpdateWidget validation and remove function for defaultData.

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -167,7 +167,7 @@ class _MyHomePageState extends State<MyHomePage> {
                           'Optional Title Widget',
                         )
                     : null,
-                defaultData: () => _defaultData ? [choices.first] : [],
+                defaultData: _defaultData ? [choices.first] : [],
                 decoration: BoxDecoration(
                     color: Colors.black12,
                     borderRadius: BorderRadius.circular(12)),

--- a/lib/core/multi_select.dart
+++ b/lib/core/multi_select.dart
@@ -60,7 +60,7 @@ class MultiSelectField<T> extends StatefulWidget {
   final Widget Function(Choice<T> choiceList)? multiSelectWidget;
   final List<Choice<T>> Function() data;
   final void Function(List<Choice<T>> choiceList) onSelect;
-  final List<Choice<T>> Function()? defaultData;
+  final List<Choice<T>>? defaultData;
   final bool isMandatory;
   final bool singleSelection;
   final bool useTextFilter;
@@ -157,9 +157,9 @@ class _MultiSelectFieldState<T> extends State<MultiSelectField<T>>
   @override
   void initState() {
     super.initState();
-    if (widget.defaultData != null && widget.defaultData!().isNotEmpty) {
+    if (widget.defaultData != null && widget.defaultData!.isNotEmpty) {
       _selectedChoice.clear();
-      _selectedChoice.addAll(widget.defaultData!());
+      _selectedChoice.addAll(widget.defaultData!);
     }
   }
 
@@ -169,9 +169,8 @@ class _MultiSelectFieldState<T> extends State<MultiSelectField<T>>
     /// A simple solution to avoid multiple updates in a single action, if necessary.
     ///
     if (widget.defaultData != null &&
-        widget.defaultData!().isNotEmpty &&
-        widget.singleSelection &&
-        _selectedChoice.isEmpty) {
+        widget.defaultData!.isNotEmpty &&
+        widget.singleSelection ) {
       /// If the current action is not removing an element, update [_selectedElements]
       /// with [defaultData]. Otherwise, keep the previous value of [_selectedElements],
       /// preventing it from being updated by [defaultData].
@@ -184,18 +183,22 @@ class _MultiSelectFieldState<T> extends State<MultiSelectField<T>>
       /// Recommendation:
       /// Over time this entire implementation should be migrated to [ValueNotifier], with a singleton abstraction.
       ///
-      _timer = Timer(const Duration(milliseconds: 100), () {
-        if (!_isUsingRemove && !_onSelected) {
-          log('didUpdateWidget multiselect');
-          _selectedChoice = widget.defaultData!();
-          widget.onSelect(_selectedChoice);
-          _selectedChoice = [];
-        }
-      });
+
+      if( !listEquals(_selectedChoice, widget.defaultData!) ) {
+        _timer = Timer(const Duration(milliseconds: 100), () {
+          if (!_isUsingRemove && !_onSelected) {
+            log('didUpdateWidget multiselect');
+            _selectedChoice = widget.defaultData!;
+            widget.onSelect(_selectedChoice);
+          }
+        });
+      }
     }
+
 
     super.didUpdateWidget(oldWidget);
   }
+
 
   @override
 

--- a/test/multiselect_field_test.dart
+++ b/test/multiselect_field_test.dart
@@ -155,7 +155,7 @@ void main() {
               child: MultiSelectField(
                 decoration: decoration,
                 singleSelection: true,
-                defaultData: () => [Choice('1', 'Item')],
+                defaultData: [Choice('1', 'Item')],
                 data: () => [],
                 onSelect: (value) {},
               ),
@@ -168,7 +168,7 @@ void main() {
               height: 70,
               child: MultiSelectField(
                 decoration: decoration,
-                defaultData: () => [Choice('1', 'Item1'), Choice('2', 'Item2')],
+                defaultData: [Choice('1', 'Item1'), Choice('2', 'Item2')],
                 data: () => [],
                 onSelect: (value) {},
               ),


### PR DESCRIPTION
This means that in cases where you need to change a default value or select an item that is not in the list, such as preloaded values, and there are several preloaded values, you can select them and you will automatically have those values ​​selected in your multiselect.

Also, if those preloaded values ​​generate changes in other widgets, you can assign the logic within onSelect:, in this way, both by changing the value in default data or selecting it from the list of our widget, they will generate a call to the onSelect function.