### PR TITLE
Remove left padding for menu style

### DIFF
--- a/lib/core/multi_select.dart
+++ b/lib/core/multi_select.dart
@@ -465,9 +465,7 @@ class _MultiSelectFieldState<T> extends State<MultiSelectField<T>>
                     return SizedBox(
                       width: widget.menuWidthBaseOnContent
                           ? null
-                          : widget.selectAllOption
-                              ? (size.maxWidth - 10)
-                              : size.maxWidth,
+                          : size.maxWidth,
                       child: MenuItemButton(
                         closeOnActivate:
                             widget.singleSelection || widget.data().length == 1,
@@ -553,10 +551,6 @@ class _MultiSelectFieldState<T> extends State<MultiSelectField<T>>
                   MenuStyle(
                     elevation: const WidgetStatePropertyAll<double>(5),
                     visualDensity: VisualDensity.adaptivePlatformDensity,
-                    padding: widget.selectAllOption
-                        ? WidgetStatePropertyAll<EdgeInsets>(
-                            EdgeInsets.only(left: 10))
-                        : null,
                     maximumSize: widget.menuWidthBaseOnContent &&
                             widget.menuHeightBaseOnContent
                         ? null


### PR DESCRIPTION
Before:
<img width="124" alt="Screenshot 2025-01-07 at 5 54 23 PM" src="https://github.com/user-attachments/assets/46c14d36-269c-4f56-800a-87c069c819cd" />

After:
<img width="91" alt="Screenshot 2025-01-07 at 5 53 58 PM" src="https://github.com/user-attachments/assets/7f892097-a4cb-4842-93a9-8ec5a51a39ef" />


A clear example that sometimes we complicate things stupidly, paff.