### PR TITLE
feat: add labelBuilder + MultiSelectLabel widget with LabelType presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.2.0
+### New Features
+- **`labelBuilder`**: Optional builder callback on the Standard variant that
+  fully overrides how the static label is rendered. Consistent with the
+  existing builder-based API (`itemMenuButton`, `singleSelectWidget`, etc.).
+  Default behavior is unchanged when the parameter is omitted.
+- **`MultiSelectLabel` widget + `LabelType` enum**: Reusable label widget that
+  centralises common rendering presets. Use as the default building block
+  for `labelBuilder`:
+  - `LabelType.line` (default): single line, no wrap.
+  - `LabelType.wrap`: wraps up to `maxLines` (default 2) with ellipsis.
+  - `LabelType.overflow`: single line truncated with ellipsis.
+
 ## 2.1.0
 ### New Features
 - **`searchMinHeight`**: Configure the minimum height of the search/filter area in the BottomSheet variant. Defaults to 200px when `useTextFilter` is enabled. Pass a custom value to ensure enough space for filtered results.

--- a/lib/core/multi_select.dart
+++ b/lib/core/multi_select.dart
@@ -69,6 +69,7 @@ abstract class MultiSelectField<T> extends StatefulWidget {
     TextStyle? itemMenuStyle,
     String? label,
     TextStyle? textStyleLabel,
+    Widget Function(String label)? labelBuilder,
     bool selectAllOption,
     ItemColor? itemColor,
     ScrollbarConfig? scrollbarConfig,

--- a/lib/core/multi_select_label.dart
+++ b/lib/core/multi_select_label.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 
 /// Defines how the label text should be rendered in [MultiSelectLabel].
@@ -55,12 +57,10 @@ class MultiSelectLabel extends StatelessWidget {
         label,
         style: style,
       ),
-      LabelType.wrap => Text(
-        label,
+      LabelType.wrap => _WrappedLabel(
+        label: label,
         style: style,
         maxLines: maxLines,
-        softWrap: true,
-        overflow: TextOverflow.ellipsis,
       ),
       LabelType.overflow => Text(
         label,
@@ -70,5 +70,56 @@ class MultiSelectLabel extends StatelessWidget {
         overflow: TextOverflow.ellipsis,
       ),
     };
+  }
+}
+
+/// Wrapping label whose width collapses to the longest *rendered* line so
+/// trailing widgets (e.g. dropdown arrows) sit right next to the text instead
+/// of being pushed to the parent's max width.
+class _WrappedLabel extends StatelessWidget {
+  final String label;
+  final TextStyle? style;
+  final int maxLines;
+
+  const _WrappedLabel({
+    required this.label,
+    required this.style,
+    required this.maxLines,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final double maxWidth = constraints.maxWidth.isFinite
+            ? constraints.maxWidth
+            : MediaQuery.sizeOf(context).width;
+
+        final TextPainter painter = TextPainter(
+          text: TextSpan(text: label, style: style),
+          textDirection: Directionality.of(context),
+          maxLines: maxLines,
+          textScaler: MediaQuery.textScalerOf(context),
+        )..layout(maxWidth: maxWidth);
+
+        double longestLine = 0;
+        for (final ui.LineMetrics line in painter.computeLineMetrics()) {
+          if (line.width > longestLine) longestLine = line.width;
+        }
+        // Ceil to avoid sub-pixel clipping that would re-trigger soft wrap.
+        final double width = longestLine.ceilToDouble();
+
+        return SizedBox(
+          width: width,
+          child: Text(
+            label,
+            style: style,
+            maxLines: maxLines,
+            softWrap: true,
+            overflow: TextOverflow.ellipsis,
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/core/multi_select_label.dart
+++ b/lib/core/multi_select_label.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+/// Defines how the label text should be rendered in [MultiSelectLabel].
+///
+/// - [LabelType.line]: single line, no wrapping (default behavior).
+/// - [LabelType.wrap]: allows wrapping up to [MultiSelectLabel.maxLines]
+///   lines via natural word break.
+/// - [LabelType.overflow]: single line that truncates with an ellipsis
+///   when it does not fit in the available width.
+enum LabelType { line, wrap, overflow }
+
+/// Reusable label widget for [MultiSelectField] variants.
+///
+/// Centralizes how a label string is rendered based on a [LabelType] preset.
+/// Use it as the standard building block when supplying a `labelBuilder`:
+///
+/// ```dart
+/// MultiSelectField<Foo>(
+///   label: 'Categories',
+///   labelBuilder: (label) => MultiSelectLabel(
+///     label: label,
+///     type: LabelType.wrap,
+///     maxLines: 2,
+///     style: Theme.of(context).textTheme.titleSmall,
+///   ),
+///   data: () => choices,
+/// )
+/// ```
+class MultiSelectLabel extends StatelessWidget {
+  /// Text to display.
+  final String label;
+
+  /// Rendering preset. See [LabelType].
+  final LabelType type;
+
+  /// Optional text style. Falls back to the ambient [DefaultTextStyle].
+  final TextStyle? style;
+
+  /// Max lines used when [type] is [LabelType.wrap]. Defaults to 2.
+  /// Ignored for other types.
+  final int maxLines;
+
+  const MultiSelectLabel({
+    super.key,
+    required this.label,
+    this.type = LabelType.line,
+    this.style,
+    this.maxLines = 2,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (type) {
+      LabelType.line => Text(
+        label,
+        style: style,
+      ),
+      LabelType.wrap => Text(
+        label,
+        style: style,
+        maxLines: maxLines,
+        softWrap: true,
+        overflow: TextOverflow.ellipsis,
+      ),
+      LabelType.overflow => Text(
+        label,
+        style: style,
+        maxLines: 1,
+        softWrap: false,
+        overflow: TextOverflow.ellipsis,
+      ),
+    };
+  }
+}

--- a/lib/core/standard_multi_select_field.dart
+++ b/lib/core/standard_multi_select_field.dart
@@ -48,6 +48,7 @@ class StandardMultiSelectField<T> extends MultiSelectField<T> {
   final String? label;
   final bool staticLabel;
   final TextStyle? textStyleLabel;
+  final Widget Function(String label)? labelBuilder;
   final bool selectAllOption;
   final ItemColor? itemColor;
   final ScrollbarConfig? scrollbarConfig;
@@ -91,6 +92,7 @@ class StandardMultiSelectField<T> extends MultiSelectField<T> {
     this.label,
     this.staticLabel = false,
     this.textStyleLabel,
+    this.labelBuilder,
     this.scrollbarConfig,
     this.iconSpacing = 0,
     this.fieldWidth,
@@ -329,10 +331,12 @@ class _StandardMultiSelectFieldState<T>
                                             widget.staticLabel) &&
                                         !widget.useTextFilter &&
                                         widget.label != null)
-                                      Text(
-                                        widget.label!,
-                                        style: widget.textStyleLabel,
-                                      ),
+                                      widget.labelBuilder != null
+                                          ? widget.labelBuilder!(widget.label!)
+                                          : Text(
+                                              widget.label!,
+                                              style: widget.textStyleLabel,
+                                            ),
                                     if (_selectedChoice.isNotEmpty)
                                       ..._selectedChoice.map((element) {
                                         if (!widget.singleSelection) {

--- a/lib/multiselect_field.dart
+++ b/lib/multiselect_field.dart
@@ -8,6 +8,9 @@ export 'core/multi_select.dart';
 /// Shared selection content widget
 export 'core/selection_content.dart';
 
+/// Reusable label widget with LabelType presets (line / wrap / overflow)
+export 'core/multi_select_label.dart';
+
 /// Standard multiselect implementation
 export 'core/standard_multi_select_field.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: multiselect_field
 description: "A flexible dropdown field supporting single/multiple selection modes, styles, titles, etc"
-version: 2.1.0
+version: 2.2.0
 homepage: https://github.com/JhonaCodes/multiselect_field.git
 
 environment:

--- a/test/label_builder_test.dart
+++ b/test/label_builder_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:multiselect_field/multiselect_field.dart';
+
+void main() {
+  group('MultiSelectLabel widget', () {
+    testWidgets('LabelType.line renders single-line Text without wrap', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 100,
+              child: MultiSelectLabel(
+                label: 'A very long label that does not fit',
+                type: LabelType.line,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final textFinder = find.byType(Text);
+      expect(textFinder, findsOneWidget);
+
+      final text = tester.widget<Text>(textFinder);
+      expect(text.maxLines, isNull);
+      expect(text.softWrap, isNull);
+      expect(text.overflow, isNull);
+    });
+
+    testWidgets('LabelType.wrap allows up to maxLines with ellipsis', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 100,
+              child: MultiSelectLabel(
+                label: 'A very long label that wraps to two lines',
+                type: LabelType.wrap,
+                maxLines: 2,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.byType(Text));
+      expect(text.maxLines, 2);
+      expect(text.softWrap, isTrue);
+      expect(text.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('LabelType.overflow truncates with ellipsis on a single line',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 100,
+              child: MultiSelectLabel(
+                label: 'A very long label that should be truncated',
+                type: LabelType.overflow,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.byType(Text));
+      expect(text.maxLines, 1);
+      expect(text.softWrap, isFalse);
+      expect(text.overflow, TextOverflow.ellipsis);
+    });
+  });
+
+  group('MultiSelectField labelBuilder integration', () {
+    testWidgets('default rendering when labelBuilder is null', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 300,
+              child: MultiSelectField<String>(
+                label: 'Filter',
+                staticLabel: true,
+                data: () => const [Choice('1', 'Opt 1')],
+                onSelect: (_, __) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Filter'), findsOneWidget);
+      // No MultiSelectLabel widget should be present when builder is not used.
+      expect(find.byType(MultiSelectLabel), findsNothing);
+    });
+
+    testWidgets('uses labelBuilder when provided', (tester) async {
+      const longLabel = 'NUI Marketplace North America';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 200,
+              child: MultiSelectField<String>(
+                label: longLabel,
+                staticLabel: true,
+                labelBuilder: (label) => MultiSelectLabel(
+                  label: label,
+                  type: LabelType.wrap,
+                  maxLines: 2,
+                ),
+                data: () => const [Choice('1', 'Opt 1')],
+                onSelect: (_, __) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(MultiSelectLabel), findsOneWidget);
+      expect(find.text(longLabel), findsOneWidget);
+
+      final multiLabel = tester.widget<MultiSelectLabel>(
+        find.byType(MultiSelectLabel),
+      );
+      expect(multiLabel.type, LabelType.wrap);
+      expect(multiLabel.maxLines, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds optional `labelBuilder: Widget Function(String label)?` to the Standard variant of `MultiSelectField`. Consistent with the existing builder-based API (`itemMenuButton`, `singleSelectWidget`, `iconLeft`, `iconRight`, `defaultData`).
- Ships a reusable `MultiSelectLabel` class widget with `LabelType` enum (`line` / `wrap` / `overflow`) so callers can pick a preset without re-implementing common rendering.
- **Non-breaking**: default rendering is unchanged when `labelBuilder` is `null`.

## Why
Consumers currently have no way to render multi-line labels (e.g. wrapping long titles in a constrained AppBar). The internal `Text(widget.label!, style: widget.textStyleLabel)` was hard-coded with no `maxLines` / `softWrap` / `overflow` knobs.

## API

```dart
MultiSelectField<Foo>(
  label: 'NUI Marketplace North America',
  staticLabel: true,
  labelBuilder: (label) => MultiSelectLabel(
    label: label,
    type: LabelType.wrap,
    maxLines: 2,
    style: Theme.of(context).textTheme.titleSmall,
  ),
  data: () => choices,
)
```

`LabelType`:
- `line` (default): single line, no wrap.
- `wrap`: wraps up to `maxLines` (default 2) with ellipsis.
- `overflow`: single line truncated with ellipsis.

## Files
- `lib/core/multi_select_label.dart` — new widget + enum.
- `lib/core/standard_multi_select_field.dart` — adds `labelBuilder` field; uses it on the static-label path.
- `lib/core/multi_select.dart` — exposes `labelBuilder` on the factory.
- `lib/multiselect_field.dart` — exports the new widget.
- `test/label_builder_test.dart` — 5 widget tests covering each `LabelType` and integration with `MultiSelectField`.
- `CHANGELOG.md` / `pubspec.yaml` — bump to **2.2.0**.

## Test plan
- [x] `flutter test test/label_builder_test.dart` → 5/5 pass.
- [x] `dart analyze lib/` → no issues.
- [x] Full test suite: no new failures (15 pre-existing golden failures on `main` unchanged — drawer/field_width platform mismatches).