### PR TITLE
fix: standard menu collapsing on tap (2.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.3.1
+### Bug Fixes
+- **Standard variant: menu collapsing on tap.** The keyboard-aware reposition
+  logic in `build()` ran on every rebuild, causing the menu to be closed and
+  reopened in the same frame whenever it was open without a soft keyboard. On
+  recent Flutter versions, that `close()`+`open()` pair on `MenuController`
+  resolved to the closed state, so each tap appeared to open and immediately
+  collapse the dropdown (and produced flicker on multi-selection rebuilds).
+  The reposition logic now runs only on actual keyboard state transitions,
+  preserving the original fix from #8 without interfering with normal taps.
+
 ## 2.3.0
 ### New Features
 - **`showSelectedTick`**: New flag on the Standard variant to control the

--- a/lib/core/standard_multi_select_field.dart
+++ b/lib/core/standard_multi_select_field.dart
@@ -131,6 +131,7 @@ class _StandardMultiSelectFieldState<T>
 
   bool _onSelected = false;
   bool _selectAllActive = false;
+  bool _wasKeyboardOpen = false;
 
   List<Choice<T>> get _cleanData => widget
       .data()
@@ -195,11 +196,17 @@ class _StandardMultiSelectFieldState<T>
     double currentMenuHeight = widget.menuHeight ?? 300;
 
     WidgetsBinding.instance.addPostFrameCallback((obs) {
-      final isKeyboardOpen = View.of(context).viewInsets.bottom > 0;
+      if (!mounted) return;
 
-      if (_menuController.isOpen && isKeyboardOpen) {
-        _menuController.open(position: Offset(0, double.infinity));
-      } else if (_menuController.isOpen && !isKeyboardOpen) {
+      final isKeyboardOpen = View.of(context).viewInsets.bottom > 0;
+      final keyboardChanged = isKeyboardOpen != _wasKeyboardOpen;
+      _wasKeyboardOpen = isKeyboardOpen;
+
+      if (!keyboardChanged || !_menuController.isOpen) return;
+
+      if (isKeyboardOpen) {
+        _menuController.open(position: const Offset(0, double.infinity));
+      } else {
         _menuController.close();
         _menuController.open();
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: multiselect_field
 description: "A flexible dropdown field supporting single/multiple selection modes, styles, titles, etc"
-version: 2.3.0
+version: 2.3.1
 homepage: https://github.com/JhonaCodes/multiselect_field.git
 
 environment:


### PR DESCRIPTION
## Summary
- Standard variant: tapping the field opened and immediately collapsed the dropdown because the keyboard-aware reposition logic in \`build()\` was running on every rebuild, calling \`MenuController.close()\` + \`open()\` in the same frame.
- Track previous keyboard state and only run the reposition on actual transitions. Preserves the original fix from #8.
- Bumps to 2.3.1.

## Test plan
- [x] \`flutter test\` — all 69 Standard-variant tests pass (\`multiselect_field_test\`, \`multiselect_field_menu_test\`, \`standard_behavior_test\`, \`menu_toggle_test\`, \`standard_extensions_test\`, \`standard_multi_select_menu_item_test\`)
- [x] Pre-existing failures on \`drawer_behavior_test\` confirmed unrelated (fail on pristine \`main\` too)
- [x] \`flutter pub publish --dry-run\` clean except expected uncommitted-files warning